### PR TITLE
Feature types & EditableGeoJson

### DIFF
--- a/csComp/classes/group.ts
+++ b/csComp/classes/group.ts
@@ -106,14 +106,23 @@ module csComp.Services {
                 var layerName = $(this).children('Name').text();
                 if (layerName != null && layerName !== '') {
                     var title = $(this).children('Title').text();
+
+                    // If <KeywordList> element has an element <keyword vocabulary="defaultFeatureType">featureType</keyword>
+                    // use featureType as defaultFeatureType
                     var featureType = $(this).children('KeywordList').children('[vocabulary="defaultFeatureType"]').text();
+                    var resourceURL = $(this).children('KeywordList').children('[vocabulary="typeResourceURL"]').text();
 
                     // TODO: should be using layerService.initLayer(theGroup, layer);
                     // But I don't know how to 'inject' layerService :(
                     var layer = theGroup.buildLayer(baseurl, title, layerName);
                     if(featureType!='') {
                         layer.defaultFeatureType = featureType;
+                        layer.typeUrl = 'data/resourceTypes/resources.json';
                     }
+                    if(resourceURL!='') {
+                        layer.typeUrl = resourceURL;
+                    }
+
                     theGroup.layers.push(layer);
                 }
             });

--- a/csComp/classes/group.ts
+++ b/csComp/classes/group.ts
@@ -30,9 +30,9 @@ module csComp.Services {
         clustering: boolean;
         /** If set, at this zoom level and below markers will not be clustered. This defaults to disabled */
         clusterLevel: number;
-        /**  
-         * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80. 
-         * Decreasing will make more smaller clusters. You can also use a function that accepts the current map 
+        /**
+         * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80.
+         * Decreasing will make more smaller clusters. You can also use a function that accepts the current map
          * zoom and returns the maximum cluster radius in pixels. */
         maxClusterRadius: number;
         clusterFunction: Function;
@@ -106,9 +106,14 @@ module csComp.Services {
                 var layerName = $(this).children('Name').text();
                 if (layerName != null && layerName !== '') {
                     var title = $(this).children('Title').text();
+                    var featureType = $(this).children('KeywordList').children('[vocabulary="defaultFeatureType"]').text();
+
                     // TODO: should be using layerService.initLayer(theGroup, layer);
                     // But I don't know how to 'inject' layerService :(
                     var layer = theGroup.buildLayer(baseurl, title, layerName);
+                    if(featureType!='') {
+                        layer.defaultFeatureType = featureType;
+                    }
                     theGroup.layers.push(layer);
                 }
             });

--- a/csComp/classes/layer.ts
+++ b/csComp/classes/layer.ts
@@ -58,6 +58,8 @@ module csComp.Services {
         refreshBBOX?: boolean;
         /** indicates that this is a dynamic layer (dynamicgeojson) */
         isDynamic?: boolean;
+        /** indicates that the contents layer of this layer can be changed */
+        isEditable?: boolean;
         /** this layer contains sensor data, updated when focusTime changes */
         hasSensorData? : boolean;
         /**
@@ -258,6 +260,9 @@ module csComp.Services {
         feature geometry and property values. changes are distributed to all active clients in realtime */
         isDynamic: boolean;
 
+        /** indicates that the contents layer of this layer can be changed */
+        isEditable: boolean;
+
         /**
          * Logging mechanism allows you to specify specific property values and geometries in time,
          * it works the same way as sensor data but is optimized for smaller amounts of data and allows not only numbers
@@ -342,6 +347,7 @@ module csComp.Services {
                 defaultLegend:         pl.defaultLegend,
                 useProxy:              pl.useProxy,
                 isDynamic:             pl.isDynamic,
+                isEditable:            pl.isEditable,
                 useLog:                pl.useLog,
                 tags:                  pl.tags,
                 hasSensorData:         pl.hasSensorData,

--- a/csComp/directives/LayersList/LayersDirectiveCtrl.ts
+++ b/csComp/directives/LayersList/LayersDirectiveCtrl.ts
@@ -369,7 +369,7 @@ module LayersDirective {
         public editLayer(layer: csComp.Services.ProjectLayer) {
             this.state = 'editlayer';
 
-            (<csComp.Services.DynamicGeoJsonSource>layer.layerSource).startEditing(layer);
+            (<csComp.Services.EditableGeoJsonSource>layer.layerSource).startEditing(layer);
             this.layer = layer;
             this.resource = null;
             if (this.layer.typeUrl) {
@@ -389,7 +389,7 @@ module LayersDirective {
                     interact('#layerfeaturetype-' + key).onend = null;
                 };
             }
-            (<csComp.Services.DynamicGeoJsonSource>layer.layerSource).stopEditing(layer);
+            (<csComp.Services.EditableGeoJsonSource>layer.layerSource).stopEditing(layer);
         }
 
         /** change layer opacity */
@@ -590,7 +590,7 @@ module LayersDirective {
                     this.editLayer(layer);
                 }
             }
-            else 
+            else
             {
                 this.$layerService.toggleLayer(layer);
             }

--- a/csComp/directives/Widgets/ButtonWidget/ButtonWidget.ts
+++ b/csComp/directives/Widgets/ButtonWidget/ButtonWidget.ts
@@ -149,20 +149,20 @@ module ButtonWidget {
         }
 
         /** start or stop editing, when starting all features are editable */
-        public toggleEditLayer(b: IButton) {            
+        public toggleEditLayer(b: IButton) {
             if (!_.isUndefined(b._layer)) {
                 var layer = b._layer;
 
                 if (layer._gui.hasOwnProperty('editing') && layer._gui['editing'] === true) {
-                    (<csComp.Services.DynamicGeoJsonSource>layer.layerSource).stopEditing(layer);
+                    (<csComp.Services.EditableGeoJsonSource>layer.layerSource).stopEditing(layer);
                     layer.data.features.forEach(f=>{
-                        delete f._gui['editMode'];                        
+                        delete f._gui['editMode'];
                         this.layerService.updateFeature(f);
-                        this.layerService.saveFeature(f); 
+                        this.layerService.saveFeature(f);
                     })
                 }
                 else {
-                    (<csComp.Services.DynamicGeoJsonSource>layer.layerSource).startEditing(layer);
+                    (<csComp.Services.EditableGeoJsonSource>layer.layerSource).startEditing(layer);
                     layer.data.features.forEach(f=>{
                         this.layerService.editFeature(f,false);
                     })
@@ -187,7 +187,7 @@ module ButtonWidget {
             if (!_.isUndefined(b._layer)) {
                 b._disabled = false;
                 b._active = b._layer.enabled;
-                b._canEdit = b._layer.enabled && b._layer.isDynamic;
+                b._canEdit = b._layer.enabled && b._layer.isEditable;
             }
             else {
                 b._disabled = true;

--- a/csComp/services/layer/LayerService.ts
+++ b/csComp/services/layer/LayerService.ts
@@ -486,6 +486,7 @@ module csComp.Services {
 
             this.layerSources['geojson'] = geojsonsource;
             this.layerSources['topojson'] = geojsonsource;
+            this.layerSources['editablegeojson'] = new EditableGeoJsonSource(this, this.$http);
             this.layerSources['dynamicgeojson'] = new DynamicGeoJsonSource(this, this.$http);
             this.layerSources['esrijson'] = new EsriJsonSource(this, this.$http);
 
@@ -841,7 +842,9 @@ module csComp.Services {
             if (!source.title) source.title = source.url;
 
             // if url starts with  'api/' this is a dynamic resource
-            source.isDynamic = (source.url.indexOf('api/') === 0) || (source.url.indexOf('/api/') === 0);
+            if (typeof(source.isDynamic) === "undefined") {
+                source.isDynamic = (source.url.indexOf('api/') === 0) || (source.url.indexOf('/api/') === 0);
+            }
 
             var featureTypes = source.featureTypes;
             if (source.propertyTypeData) {
@@ -2793,6 +2796,7 @@ module csComp.Services {
             layer._gui = {};
             layer.renderType = (layer.renderType) ? layer.renderType.toLowerCase() : layer.type;
             if (layer.type === 'dynamicgeojson') layer.isDynamic = true;
+            if (layer.type === 'editablegeojson' || layer.isDynamic) layer.isEditable = true;
             if (layer.reference == null) layer.reference = layer.id; //Helpers.getGuid();
             if (layer.title == null) layer.title = layer.id;
             if (layer.languages != null && this.currentLocale in layer.languages) {

--- a/csComp/services/layer/sources/GeoJsonSource.ts
+++ b/csComp/services/layer/sources/GeoJsonSource.ts
@@ -55,6 +55,13 @@ module csComp.Services {
                         layer.enabled = true;
                         this.initLayer(data, layer);
                         cb(null, null);
+                    } else if (!layer.url && layer.data && layer.data.type) {
+                        if (!layer.count) layer.count = 0;
+                        layer.enabled = true;
+                        layer.isLoading = false;
+                        layer.isConnected = false;
+                        this.initLayer(layer.data, layer);
+                        cb(null, null);
                     } else {
                         // Open a layer URL
                         layer.isLoading = true;
@@ -251,9 +258,8 @@ module csComp.Services {
         }
     }
 
-    export class DynamicGeoJsonSource extends GeoJsonSource {
-        title = 'dynamicgeojson';
-        connection: Connection;
+    export class EditableGeoJsonSource extends GeoJsonSource {
+        title = 'editablegeojson';
 
         constructor(public service: LayerService, $http: ng.IHttpService) {
             super(service, $http);
@@ -424,7 +430,7 @@ module csComp.Services {
         }
 
         public addLayer(layer: ProjectLayer, callback: (layer: ProjectLayer) => void, data = null) {
-            layer.isDynamic = true;
+            layer.isEditable = true;
             this.baseAddLayer(layer, (layer: ProjectLayer) => {
                 callback(layer);
                 if (layer.enabled) {
@@ -485,13 +491,26 @@ module csComp.Services {
             if (!layer || !layer.typeUrl || !this.service.typesResources.hasOwnProperty(layer.typeUrl)) return;
             for (var ft in this.service.typesResources[this.layer.typeUrl].featureTypes) {
                 var t = this.service.typesResources[this.layer.typeUrl].featureTypes[ft];
-                if (!t.style.drawingMode) t.style.drawingMode = 'Point';                
+                if (!t.style.drawingMode) t.style.drawingMode = 'Point';
                 featureTypes[ft] = this.service.typesResources[this.layer.typeUrl].featureTypes[ft];
-                featureTypes[ft].u = csComp.Helpers.getImageUri(ft);                
+                featureTypes[ft].u = csComp.Helpers.getImageUri(ft);
             }
         }
 
+    }
 
+    export class DynamicGeoJsonSource extends EditableGeoJsonSource {
+        title: "dynamicgeojson";
+        connection: Connection;
+
+        constructor(public service: LayerService, $http: ng.IHttpService) {
+            super(service, $http);
+        }
+
+        public addLayer(layer: ProjectLayer, callback: (layer: ProjectLayer) => void, data = null) {
+            layer.isDynamic = true;
+            super.addLayer(layer, callback, data);
+        }
     }
 
     export interface IOtpLeg {

--- a/csComp/services/map/renderers/cesiumRenderer.ts
+++ b/csComp/services/map/renderers/cesiumRenderer.ts
@@ -326,6 +326,7 @@ module csComp.Services {
             var dfd = jQuery.Deferred();
             switch (layer.type.toUpperCase()) {
                 case 'GEOJSON':
+                case 'EDITABLEGEOJSON':
                 case 'DYNAMICGEOJSON':
                 case 'TOPOJSON':
                     setTimeout(() => {

--- a/test/csComp/spec/services/layer/LayerService.spec.ts
+++ b/test/csComp/spec/services/layer/LayerService.spec.ts
@@ -50,8 +50,8 @@ describe('csComp.Services.LayerService', function() {
         it('should have layersource geojson', () => {
             expect(layerService.layerSources.hasOwnProperty('geojson')).toBeTruthy();
         });
-        it('should have layersource geojson', () => {
-            expect(layerService.layerSources.hasOwnProperty('geojson')).toBeTruthy();
+        it('should have layersource editablegeojson', () => {
+            expect(layerService.layerSources.hasOwnProperty('editablegeojson')).toBeTruthy();
         });
         it('should have layersource topojson', () => {
             expect(layerService.layerSources.hasOwnProperty('topojson')).toBeTruthy();


### PR DESCRIPTION
1. We have added a way to specify the featureTypes from OWS (Geographic Webservice)
2. Extracted the editable part of DynamicGeoJson to a new class called EditableGeoJson which is not stored anywhere. DynamicGeoJson is now a subclass of EditableGeoJson. This allows us to have editable layers, where you can drag and drop new features to, that are session only.