### PR TITLE
Fixed click region for buttonwidget

### DIFF
--- a/csComp/directives/Widgets/ButtonWidget/ButtonWidget.tpl.html
+++ b/csComp/directives/Widgets/ButtonWidget/ButtonWidget.tpl.html
@@ -1,8 +1,8 @@
 <div style="width:100%;height:100%">
     <!-- Extended layout (vertical orientation, description & legend options, etc.) -->
     <div ng-if="!data.minimalLayout">
-        <div ng-repeat="b in $parent.buttons" class="s3d button-container" ng-class="{'button-container-down': b._active}">
-            <div class="button-widget-content" ng-click="$parent.$parent.vm.click(b)">
+        <div ng-repeat="b in $parent.buttons" class="s3d button-container" ng-class="{'button-container-down': b._active}" ng-click="$parent.$parent.vm.click(b)">
+            <div class="button-widget-content">
                 <img ng-class="{'button-widget-image': (!b._active || !b.showLegend), 'button-widget-image-active': (b._active && b.showLegend)}"
                     ng-if="b.image" ng-src="{{b.image}}"></img>
                 {{b.title}}
@@ -46,16 +46,16 @@
     </div>
     <!-- Minimalistic layout (horizontal orientation, image only (with title as tooltip), no description & legend options) -->
     <div ng-if="data.minimalLayout&&!data.toggleMode" style="width:100%;height:100%;display:inline-block;">
-        <div ng-repeat="b in $parent.buttons" class="button-container-minimal" ng-style="{'width': (98 / $parent.buttons.length)+'%'}">
-            <div class="button-widget-content" ng-click="$parent.$parent.vm.click(b)" uib-popover="{{b.title}}" popover-trigger="mouseenter">
+        <div ng-repeat="b in $parent.buttons" class="button-container-minimal" ng-style="{'width': (98 / $parent.buttons.length)+'%'}" ng-click="$parent.$parent.vm.click(b)">
+            <div class="button-widget-content" uib-popover="{{b.title}}" popover-trigger="mouseenter">
                 <img class="button-widget-image-minimal" ng-class="{'down': b._active}" ng-if="b.image" ng-src="{{b.image}}">
             </div>
         </div>
     </div>
     <!-- Minimalistic layout (horizontal orientation, image only (with title as tooltip), no description & legend options) -->
     <div ng-if="data.minimalLayout&&data.toggleMode" style="width:100%;height:100%;display:inline-block;" ng-init="$parent.activeIndex=0">
-        <div ng-repeat="b in $parent.buttons track by $index" class="button-container-minimal" style="width:100%" ng-show="$index==$parent.$parent.activeIndex" >
-            <div class="button-widget-content" ng-click="$parent.$parent.vm.click(b);" uib-popover="{{b.title}}" popover-trigger="mouseenter">
+        <div ng-repeat="b in $parent.buttons track by $index" class="button-container-minimal" style="width:100%" ng-show="$index==$parent.$parent.activeIndex" ng-click="$parent.$parent.vm.click(b);" >
+            <div class="button-widget-content" uib-popover="{{b.title}}" popover-trigger="mouseenter">
                 <img class="button-widget-image-minimal" ng-class="{'down': b._active}" ng-if="b.image" ng-src="{{b.image}}"/>
             </div>
         </div>


### PR DESCRIPTION
Click region for the button widget was only the content. Since the whole button widget area responds to mouseover, this is a bit counterintuitive, so I made the whole button widget area respond to clicks.