### PR TITLE
Wms Test Fixes

### DIFF
--- a/csComp/classes/group.ts
+++ b/csComp/classes/group.ts
@@ -84,7 +84,7 @@ module csComp.Services {
             return res;
         }
 
-        public loadLayersFromOWS($injector: ng.auto.IInjectorService = null): void {
+        public loadLayersFromOWS($injector: ng.auto.IInjectorService = null, onSuccess?: () => void): void {
             this.layers = [];   // add some layers here...
             this.isLoading = true;
 
@@ -96,6 +96,7 @@ module csComp.Services {
                     .then((res: {data: any}) => {
                         this.parseXML(res.data, $timeout);
                         this.isLoading = false;
+                        onSuccess();
                     },
                     (xml, status) => {
                         console.log('Unable to load OWSurl: ' + this.owsurl);

--- a/test/csComp/spec/classes/group.spec.ts
+++ b/test/csComp/spec/classes/group.spec.ts
@@ -53,13 +53,13 @@ describe('ProjectGroup', function() {
 
             projectgroup.owsurl = targetURL;
             projectgroup.loadLayersFromOWS($myInjector, () => {
+                $httpBackend.expectGET(targetURL);
+                $httpBackend.flush();
+                $httpBackend.verifyNoOutstandingExpectation();
+                $httpBackend.verifyNoOutstandingRequest();
                 expect(projectgroup.layers).not.toBe(null);
                 expect(projectgroup.layers.length).toBeGreaterThan(0);
             });
-            $httpBackend.expectGET(targetURL);
-            $httpBackend.flush();
-            $httpBackend.verifyNoOutstandingExpectation();
-            $httpBackend.verifyNoOutstandingRequest();
         });
     });
 });

--- a/test/csComp/spec/classes/group.spec.ts
+++ b/test/csComp/spec/classes/group.spec.ts
@@ -52,15 +52,14 @@ describe('ProjectGroup', function() {
             $httpBackend.whenGET(targetURL).respond(200, fakeXML);
 
             projectgroup.owsurl = targetURL;
-            projectgroup.loadLayersFromOWS($myInjector);
-
+            projectgroup.loadLayersFromOWS($myInjector, () => {
+                expect(projectgroup.layers).not.toBe(null);
+                expect(projectgroup.layers.length).toBeGreaterThan(0);
+            });
             $httpBackend.expectGET(targetURL);
             $httpBackend.flush();
             $httpBackend.verifyNoOutstandingExpectation();
             $httpBackend.verifyNoOutstandingRequest();
-
-            expect(projectgroup.layers).not.toBe(null);
-            expect(projectgroup.layers.length).toBeGreaterThan(0);
         });
     });
 });


### PR DESCRIPTION
Added an onSuccess callback function to the loadLayersFromOWS function.

I couldn't figure out where to return a promise from this function, so I went with this approach.

The test has been updated to use the callback to continue the test.